### PR TITLE
Add QoL and shell standardization

### DIFF
--- a/sh/spotify_artist.sh
+++ b/sh/spotify_artist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
  
-artist=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|egrep -A 2 "artist"|egrep -v "artist"|egrep -v "array"|cut -b 27-|cut -d '"' -f 1|egrep -v ^$`
-echo $artist
+artist=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 2 "artist"|grep -E -v "artist"|grep -E -v "array"|cut -b 27-|cut -d '"' -f 1|grep -E -v ^$)
+echo "$artist"

--- a/sh/spotify_playback_progress.sh
+++ b/sh/spotify_playback_progress.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
  
-progress=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Position' | tail -1`
-progress=`echo $progress | awk '{print $NF}'`
-length=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 1 "length"|grep -E -v "length"|cut -b 43-|cut -d '"' -f 1|grep -E -v ^$`
+progress=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Position' | tail -1)
+progress=$(echo "$progress" | awk '{print $NF}')
+length=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 1 "length"|grep -E -v "length"|cut -b 43-|cut -d '"' -f 1|grep -E -v ^$)
 
 echo "scale=2 ; ($progress / $length) * 100" | bc

--- a/sh/spotify_status.sh
+++ b/sh/spotify_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
  
-status=` dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | tail -1 | cut -d "\"" -f2`
-echo $status
+status=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'PlaybackStatus' | tail -1 | cut -d "\"" -f2)
+echo "$status"

--- a/sh/spotify_title.sh
+++ b/sh/spotify_title.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-title=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 1 "title"|grep -E -v "title"|cut -b 44-|cut -d '"' -f 1|grep -E -v ^$`
-echo $title
+title=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'|grep -E -A 1 "title"|grep -E -v "title"|cut -b 44-|cut -d '"' -f 1|grep -E -v ^$)
+echo "$title"

--- a/startup.sh
+++ b/startup.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
+trap exit_trap EXIT
+set -e
+
+exit_trap () {
+  local lc="$BASH_COMMAND" rc=$?
+  if [ $rc -ne 0 ]; then
+    echo -e "\nCommand \033[1m[$lc]\033[0m exited with code [$rc]\n
+            To debug try to execute this command by yourself without '-q' flag"
+  fi
+}
+
 # [ Conky startup script ]
 echo 'starting Conky...'
 sleep 1
-conky -c ~/.config/conky/conkula/conky_config/conky_clock.lua > /dev/null
+conky -qc ~/.config/conky/conkula/conky_config/conky_clock.lua
 echo 'Clock is up...'
 sleep 1
-conky -c ~/.config/conky/conkula/conky_config/conky_weather.lua > /dev/null
+conky -qc ~/.config/conky/conkula/conky_config/conky_weather.lua
 echo 'Weather info is up...'
 sleep 1
-conky -c ~/.config/conky/conkula/conky_config/conky_system.lua > /dev/null
+conky -qc ~/.config/conky/conkula/conky_config/conky_system.lua
 echo 'System info is up...'
 sleep 1
-conky -c ~/.config/conky/conkula/conky_config/conky_spotify.lua > /dev/null
+conky -qc ~/.config/conky/conkula/conky_config/conky_spotify.lua
 echo 'Spotify info is up...'
-sleep 1
-exit
+

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 trap exit_trap EXIT
 set -e
@@ -7,7 +7,7 @@ exit_trap () {
   local lc="$BASH_COMMAND" rc=$?
   if [ $rc -ne 0 ]; then
     echo -e "\nCommand \033[1m[$lc]\033[0m exited with code [$rc]\n
-            To debug try to execute this command by yourself without '-q' flag"
+            To debug try to execute this command by yourself \033[4mwithout\033[0m '-q' flag"
   fi
 }
 


### PR DESCRIPTION
- Set quiet (`-q`) output for Conky. Just an eye candy during startup without unnecessary logs
- Simple error handling for ` startup.sh`
- Kosher shebang - `#!/usr/bin/env bash` instead of `#!/bin/bash` 
- Implement [shellcheck](https://github.com/koalaman/shellcheck) suggestions, i.e `grep -E` instead of non-standard `egrep`, double quotes to prevent word splitting and so on